### PR TITLE
Inset Specification on X Axis to Fix Style Clashes

### DIFF
--- a/resources/views/toolbar.blade.php
+++ b/resources/views/toolbar.blade.php
@@ -1,7 +1,7 @@
-<div x-data="wireSpy" x-on:keydown.window.prevent.super.l="show = !show" x-cloak :style="show ? `height: ${height}px;` : `height: 0`;" :class="isResizing ? '' : 'transition-all'" class="font-sans antialiased fixed z-[99999999] flex flex-col inset bottom-0 w-full bg-zinc-900 rounded-t-lg text-gray-300">
+<div x-data="wireSpy" x-on:keydown.window.prevent.super.l="show = !show" x-cloak :style="show ? `height: ${height}px;` : `height: 0`;" :class="isResizing ? '' : 'transition-all'" class="font-sans antialiased fixed z-[99999999] flex flex-col inset-x-0 bottom-0 w-full bg-zinc-900 rounded-t-lg text-gray-300">
     @include('wire-spy::navbar')
 
-    <div class="flex flex-1 overflow-hidden">
+    <div class="flex overflow-hidden flex-1">
         @include('wire-spy::tabs.components')
         @include('wire-spy::tabs.requests')
         @include('wire-spy::tabs.events')

--- a/resources/views/toolbar.blade.php
+++ b/resources/views/toolbar.blade.php
@@ -1,7 +1,7 @@
 <div x-data="wireSpy" x-on:keydown.window.prevent.super.l="show = !show" x-cloak :style="show ? `height: ${height}px;` : `height: 0`;" :class="isResizing ? '' : 'transition-all'" class="font-sans antialiased fixed z-[99999999] flex flex-col inset-x-0 bottom-0 w-full bg-zinc-900 rounded-t-lg text-gray-300">
     @include('wire-spy::navbar')
 
-    <div class="flex overflow-hidden flex-1">
+    <div class="flex flex-1 overflow-hidden">
         @include('wire-spy::tabs.components')
         @include('wire-spy::tabs.requests')
         @include('wire-spy::tabs.events')


### PR DESCRIPTION
I noticed when using WireSpy with my personal starter kit ( with Flux), if I had styles on the body like min-h or max-w, it would clash and either not show completely or just be pushed over.

I don't know the exact style clashes, but I do know that setting the inset on the x axis fixes it. 😅

You can test with [my starter kit in it's current state](https://github.com/joshcirre/fission).