### PR TITLE
fix: open toolbar with Ctrl + L

### DIFF
--- a/resources/views/toolbar.blade.php
+++ b/resources/views/toolbar.blade.php
@@ -1,4 +1,4 @@
-<div x-data="wireSpy" x-on:keydown.window.prevent.super.l="show = !show" x-cloak :style="show ? `height: ${height}px;` : `height: 0`;" :class="isResizing ? '' : 'transition-all'" class="font-sans antialiased fixed z-[99999999] flex flex-col inset left-0 bottom-0 w-full bg-zinc-900 rounded-t-lg text-gray-300">
+<div x-data="wireSpy" x-on:keydown.window.prevent.ctrl.l="show = !show" x-on:keydown.window.prevent.super.l="show = !show" x-cloak :style="show ? `height: ${height}px;` : `height: 0`;" :class="isResizing ? '' : 'transition-all'" class="font-sans antialiased fixed z-[99999999] flex flex-col inset left-0 bottom-0 w-full bg-zinc-900 rounded-t-lg text-gray-300">
     @include('wire-spy::navbar')
 
     <div class="flex flex-1 overflow-hidden">


### PR DESCRIPTION
Ctrl + L does not work on Windows using Chrome; it focuses on Chrome's search bar instead. This pull request makes Ctrl + L toggle the toolbar, as mentioned in the docs.