### PR TITLE
fix duplicate event loop keys

### DIFF
--- a/resources/views/tabs/events.blade.php
+++ b/resources/views/tabs/events.blade.php
@@ -13,7 +13,7 @@
                 </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-800">
-                <template x-for="event in getEvents()" :key="event.commitId">
+                <template x-for="(event, index) in getEvents()" x-bind:key="`${event.commitId}-${index}`">
                     <tr>
                         <td class="whitespace-nowrap align-top py-4 pl-4 pr-3 text-sm text-white" x-text="event.name"></td>
                         <td class="whitespace-nowrap align-top py-4 pl-4 pr-3 text-sm text-white">

--- a/resources/views/tabs/events.blade.php
+++ b/resources/views/tabs/events.blade.php
@@ -13,7 +13,7 @@
                 </tr>
                 </thead>
                 <tbody class="divide-y divide-gray-800">
-                <template x-for="(event, index) in getEvents()" x-bind:key="`${event.commitId}-${index}`">
+                <template x-for="event in getEvents()" :id="$id('wire-spy-event-commit-id')">
                     <tr>
                         <td class="whitespace-nowrap align-top py-4 pl-4 pr-3 text-sm text-white" x-text="event.name"></td>
                         <td class="whitespace-nowrap align-top py-4 pl-4 pr-3 text-sm text-white">


### PR DESCRIPTION
I get tons of errors, mostly when opening/closing modals and showing notifications.
It crashes Alpine and the page...

This PR fixes that.
<img width="1682" alt="image" src="https://github.com/user-attachments/assets/b4a88405-306b-47cd-ab51-5d542ae9d7fa">


I printed out the event.commitId and it shows that it is not unique when a page sends multiple events.
<img width="328" alt="image" src="https://github.com/user-attachments/assets/1a5cfede-3c04-4080-8e90-e35f60d8143c">


Don't know if it is better with [Keyed ids](https://alpinejs.dev/magics/id#keyed-ids), but the solution in this PR works for me.
