### PR TITLE
Make enabling the wire-spy package environment aware through an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,7 @@ To change the keybinding, publish the configuration file, run:
 php artisan vendor:publish --tag=wire-spy-config
 ```
 
-
+If you want to disable wire-spy, add the folowing line to your .env file:
+```dotenv
+WIRESPY_ENABLED=false
+```

--- a/src/WireSpyServiceProvider.php
+++ b/src/WireSpyServiceProvider.php
@@ -11,11 +11,13 @@ class WireSpyServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
-        if (App::runningUnitTests()) {
+
+        $this->registerPackageConfig();
+
+        if (!$this->app['config']->get('wire-spy.enabled')) {
             return;
         }
-        
-        $this->registerPackageConfig();
+
         $this->registerLivewireComponent();
         $this->registerBladeViews();
         $this->registerLivewireComponentHooks();

--- a/src/config/wire-spy.php
+++ b/src/config/wire-spy.php
@@ -10,4 +10,6 @@ return [
     * - Combine with other keys using dot notation, like 'super.l' for 'Cmd+L' or 'Ctrl+L'.
     */
     'keybinding' => 'super.l',
+
+    'enabled' => env('WIRESPY_ENABLED', true),
 ];


### PR DESCRIPTION
As with automated testing you don't want the wire-spy to be active. But there could also be other situations where you don't want the wire-spy to be active. With this adjustment, you can set an env variable to switch off wire-spy