### PR TITLE
Update sleep to usleep  to correct waiting time and erase warrnings

### DIFF
--- a/src/SupportHotReloading.php
+++ b/src/SupportHotReloading.php
@@ -109,7 +109,7 @@ class SupportHotReloading extends ComponentHook
                     $filesByTime[$file] = $time;
                 }
 
-                sleep(.25);
+                usleep(250);
 
                 // Every 5 seconds we send a ping to keep the connection alive
                 if (! $lastPing || microtime(true) > ($lastPing + 5)) {


### PR DESCRIPTION
Warrning showing the .25 implicit waiting isn't the best practise. And laravel Herd dump interface floating with warrning message. More than 1000. usleap do same, but parameter millisecond insted of seccond