### PR TITLE
Override keybinding using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ To change the keybinding, publish the configuration file by running:
 php artisan vendor:publish --tag=wire-spy-config
 ```
 
+Then, edit the `wire-spy.php` file in `config/wire-spy.php` to change the keybinding.
+
+In a shared repoository where the keybding may need differ between developers, you can override the keybinding by setting an environment variable:, e.g.:
+
+```dotenv
+WIRE_SPY_KEYBINDING="ctrl.shift.y"
+```
+
 By default, WireSpy is enabled only in your `local` environment. You can override this in `config/wire-spy.php` or by setting an environment variable:
 
 ```dotenv

--- a/config/wire-spy.php
+++ b/config/wire-spy.php
@@ -15,5 +15,5 @@ return [
      * - 'super' corresponds to the 'Cmd' key on macOS and the 'Ctrl' key on Windows/Linux.
      * - Combine with other keys using dot notation, like 'super.l' for 'Cmd+L' or 'Ctrl+L'.
      */
-    'keybinding' => 'super.l',
+    'keybinding' => env('WIRE_SPY_KEYBINDING', 'super.l'),
 ];


### PR DESCRIPTION
This pull request modifies the keybinding configuration, allowing for customization via an environment variable.  The changes involve both documentation updates and modifications to the configuration file.  It retains the existing default keybinding in the absence of the .env key.

The rationale for the change is to allow different developers in the same repository to customize the keybinding based on their personal preference and desktop environment without constantly changing the config file.

Example of change:

```dotenv
WIRE_SPY_KEYBINDING="ctrl.shift.y"
```