### PR TITLE
Fix:  debug bar layout in RTL mode by adding dir='ltr'"

### DIFF
--- a/src/SupportAutoInjectedAssets.php
+++ b/src/SupportAutoInjectedAssets.php
@@ -34,7 +34,7 @@ class SupportAutoInjectedAssets extends ComponentHook
 
                 $assetsHead .= sprintf('<style>%s</style>', file_get_contents(base_path('vendor/wire-elements/wire-spy/dist/wire-spy.min.css')))."\n";
                 $assetsBody .= sprintf('<script src="/livewire/wire-spy.min.js?id=%s"></script>', $cacheId)."\n";
-                $assetsBody .= Blade::render('<div class="wire-spy"><livewire:wire-spy /></div>');
+                $assetsBody .= Blade::render('<div dir="ltr" class="wire-spy"><livewire:wire-spy /></div>');
             }
 
             if ($assetsHead === '' && $assetsBody === '') {


### PR DESCRIPTION
## Title: 
Fix RTL layout issue in debug bar.

## Description: 
Added dir="ltr" to ensure proper layout of wire-spy debug bar in RTL environments.


![firefox_aqJTxBwQvp](https://github.com/user-attachments/assets/b0e7b356-a5fa-489d-a020-1f644c2f70ec)

