### PR TITLE
feat: add optional on-screen toggle button for WireSpy panel

### DIFF
--- a/config/wire-spy.php
+++ b/config/wire-spy.php
@@ -16,4 +16,12 @@ return [
      * - Combine with other keys using dot notation, like 'super.l' for 'Cmd+L' or 'Ctrl+L'.
      */
     'keybinding' => 'super.l',
+
+
+    /**
+     * By default WireSpy can only be triggered by keyboard shortcuts.
+     * If you need to trigger the panel's visibility by a button either set the WIRE_SPY_BUTTON_ENABLED to true
+     * in your .env file or publish the config file and set the value to true.
+     */
+    'button_enabled' => env('WIRE_SPY_BUTTON_ENABLED', false),
 ];

--- a/resources/views/toolbar.blade.php
+++ b/resources/views/toolbar.blade.php
@@ -1,4 +1,4 @@
-<div x-data="wireSpy" x-on:keydown.window.prevent.{{ config('wire-spy.keybinding', 'super.l') }}="show = !show" x-cloak :style="show ? `height: ${height}px;` : `height: 0`;" :class="isResizing ? '' : 'transition-all'" class="font-sans antialiased fixed z-[99999999] flex flex-col inset left-0 bottom-0 w-full bg-zinc-900 rounded-t-lg text-gray-300">
+<div x-data="wireSpy" x-on:keydown.window.prevent.{{ config('wire-spy.keybinding', 'super.l') }}="show = !show"  @wire-spy-toggle.window="show = !show" x-cloak :style="show ? `height: ${height}px;` : `height: 0`;" :class="isResizing ? '' : 'transition-all'" class="font-sans antialiased fixed z-[99999999] flex flex-col inset left-0 bottom-0 w-full bg-zinc-900 rounded-t-lg text-gray-300">
     @include('wire-spy::navbar')
 
     <div class="flex flex-1 overflow-hidden">

--- a/resources/views/trigger.blade.php
+++ b/resources/views/trigger.blade.php
@@ -1,0 +1,30 @@
+<button
+    x-data
+    @click="$dispatch('wire-spy-toggle')"
+    style="
+        position: fixed;
+        bottom: 16px;
+        right: 16px;
+        z-index: 99999999;
+
+        display: flex;
+        align-items: center;
+        justify-content: center;
+
+        width: 40px;
+        height: 40px;
+
+        border-radius: 9999px;
+        background: #18181b;
+        color: #e5e7eb;
+
+        font-size: 18px;
+        line-height: 1;
+
+        cursor: pointer;
+        box-shadow: 0 4px 12px rgba(0,0,0,.4);
+    "
+    title="Toggle WireSpy"
+>
+    🐞
+</button>

--- a/src/SupportAutoInjectedAssets.php
+++ b/src/SupportAutoInjectedAssets.php
@@ -34,7 +34,17 @@ class SupportAutoInjectedAssets extends ComponentHook
 
                 $assetsHead .= sprintf('<style>%s</style>', file_get_contents(base_path('vendor/wire-elements/wire-spy/dist/wire-spy.min.css')))."\n";
                 $assetsBody .= sprintf('<script src="/livewire/wire-spy.min.js?id=%s"></script>', $cacheId)."\n";
-                $assetsBody .= Blade::render('<div class="wire-spy"><livewire:wire-spy /></div>');
+                if (static::shouldInjectWireSpyTriggerButton()) {
+                    $assetsBody .= view('wire-spy::trigger')->render() . "\n";
+                }
+                $assetsBody .= Blade::render('
+                    <div class="wire-spy-root">
+                        <div id="wire-spy-trigger"></div>
+                        <div class="wire-spy">
+                            <livewire:wire-spy />
+                        </div>
+                    </div>
+                ');
             }
 
             if ($assetsHead === '' && $assetsBody === '') {
@@ -62,5 +72,11 @@ class SupportAutoInjectedAssets extends ComponentHook
         }
 
         return false;
+    }
+
+    protected static function shouldInjectWireSpyTriggerButton(): bool
+    {
+        return static::shouldInjectWireSpyAssets() 
+            && config('wire-spy.button_enabled');
     }
 }


### PR DESCRIPTION
### What this does
Adds an optional on-screen toggle button to open/close the WireSpy debug panel.

### Why
Keyboard shortcuts can conflict with OS/browser shortcuts, making the panel
inaccessible for some users.

## How
### Reuses existing toggle logic
```
@wire-spy-toggle.window="show = !show"
```
### Button is optional via config
- No behavior changes by default
```
<?php

return [
    /*
     * Enable or disable WireSpy.
     * By default, WireSpy will only be enabled in your development environment.
     */
    'enabled' => env('WIRE_SPY_ENABLED'),

    /**
     * The keybinding configuration option allows you to define a keyboard shortcut
     * using AlpineJS syntax. It accepts a string representing the desired key combination.
     *
     * Syntax:
     * - 'super' corresponds to the 'Cmd' key on macOS and the 'Ctrl' key on Windows/Linux.
     * - Combine with other keys using dot notation, like 'super.l' for 'Cmd+L' or 'Ctrl+L'.
     */
    'keybinding' => 'super.l',


    /**
     * By default WireSpy can only be triggered by keyboard shortcuts.
     * If you need to trigger the panel's visibility by a button either set the WIRE_SPY_BUTTON_ENABLED to true
     * in your .env file or publish the config file and set the value to true.
     */
    'button_enabled' => env('WIRE_SPY_BUTTON_ENABLED', false),
];

```

### Added trigger.blade.php
- Button styling is basic. It could definitely use some work.
```
<button
    x-data
    @click="$dispatch('wire-spy-toggle')"
    style="
        position: fixed;
        bottom: 16px;
        right: 16px;
        z-index: 99999999;

        display: flex;
        align-items: center;
        justify-content: center;

        width: 40px;
        height: 40px;

        border-radius: 9999px;
        background: #18181b;
        color: #e5e7eb;

        font-size: 18px;
        line-height: 1;

        cursor: pointer;
        box-shadow: 0 4px 12px rgba(0,0,0,.4);
    "
    title="Toggle WireSpy"
>
    🐞
</button>

```

### Screenshots
<img width="399" height="239" alt="image" src="https://github.com/user-attachments/assets/5d78bd0c-1cd7-49a2-b4ff-293e075d65a2" />

### Works globally. 
(The entire reason I did this is that I needed to be able to trigger it while building a Filament panel).
<img width="1886" height="946" alt="image" src="https://github.com/user-attachments/assets/fbd18925-e0d0-4235-adaa-aba85917e39e" />
